### PR TITLE
Fix katakana and hiragana search interchangeability

### DIFF
--- a/src/services/apis/parseGanaCode.js
+++ b/src/services/apis/parseGanaCode.js
@@ -1,0 +1,11 @@
+export const parseKatakanaToHiragana = oriStr => {
+  return oriStr
+    .split("")
+    .map(letter => {
+      const code10 = letter.charCodeAt(0);
+      return code10 > 12448 && code10 < 12543 // Unicode range for Katakana
+        ? String.fromCharCode(code10 - 96) // Difference between Hiragana and Katakana in decimal for same letter
+        : letter;
+    })
+    .join("");
+};

--- a/src/services/apis/parseGanaCode.js
+++ b/src/services/apis/parseGanaCode.js
@@ -1,10 +1,14 @@
+const KATAKANA_START = 12448;
+const KATAKANA_END = 12543;
+const DIFF_KATAKANA_HIRAGANA = 96;
+
 export const parseKatakanaToHiragana = oriStr => {
   return oriStr
     .split("")
     .map(letter => {
       const code10 = letter.charCodeAt(0);
-      return code10 > 12448 && code10 < 12543 // Unicode range for Katakana
-        ? String.fromCharCode(code10 - 96) // Difference between Hiragana and Katakana in decimal for same letter
+      return code10 > KATAKANA_START && code10 < KATAKANA_END
+        ? String.fromCharCode(code10 - DIFF_KATAKANA_HIRAGANA)
         : letter;
     })
     .join("");

--- a/src/services/apis/search.js
+++ b/src/services/apis/search.js
@@ -1,8 +1,11 @@
 import { members } from "../../constants/member";
 import { photoClass } from "../../constants/photoClass";
+import { parseKatakanaToHiragana } from "./parseGanaCode";
 
 export const search = (photoInts, keyword) => {
-  const keywordRegexp = new RegExp(keyword.toLowerCase());
+  const keywordRegexp = new RegExp(
+    parseKatakanaToHiragana(keyword.toLowerCase())
+  );
   return photoInts.filter(photoInt => {
     return (
       keywordRegexp.exec(photoInt.photo_member.toLowerCase()) !== null || // En
@@ -17,9 +20,11 @@ export const search = (photoInts, keyword) => {
         ).member_name_gana // Gana
       ) !== null ||
       keywordRegexp.exec(
-        photoClass
-          .find(photoCl => photoCl.photo_id === photoInt.photo_costume) //Costume
-          .photo_name.toLowerCase()
+        parseKatakanaToHiragana(
+          photoClass
+            .find(photoCl => photoCl.photo_id === photoInt.photo_costume) //Costume
+            .photo_name.toLowerCase()
+        )
       ) !== null
     );
   });


### PR DESCRIPTION
Parse char code in decimal then check if it's in the range for katakana for `keywordSearch` and `photoCostume`. If true return string from its char code - 96. (the difference between hiragana and katakana in decimal unicode for same letter)
This fixes #64 .